### PR TITLE
chore: update rust-dashcore dependency to store TransactionContext in TransactionRecord

### DIFF
--- a/ferment-example/app/Cargo.toml
+++ b/ferment-example/app/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.95"
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, branch = "feat/ferment" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 
 ferment.workspace = true
 ferment-macro.workspace = true

--- a/ferment-example/nested/Cargo.toml
+++ b/ferment-example/nested/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.95"
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, branch = "feat/ferment" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 
 ferment.workspace = true
 ferment-macro.workspace = true

--- a/ferment-example/platform/Cargo.toml
+++ b/ferment-example/platform/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.75" }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, branch = "feat/ferment" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = ["std", "secp-recovery", "rand", "signer", "serde", "apple"], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 ferment.workspace = true
 ferment-macro.workspace = true
 grovedb-version = "2.1.0"


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#582](https://github.com/dashpay/rust-dashcore/pull/582).

**What:** Updated all `dashcore`/`dashcore-rpc` git dependencies to PR HEAD commit (`5114330ae564858803d656efba84bb4adacb2a2e`).

**Why:** Validates that the changes in rust-dashcore PR #582 (`refactor: store TransactionContext in TransactionRecord`) compile and pass CI against this repository.

**Changes:** Dependency pointer update only — no functional code changes.